### PR TITLE
Add flake8 to find syntax errors & undefined names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,5 +5,10 @@ jobs:
       - image: eulertour/manim:circleci
     steps:
       - checkout
-      - run:
-          command: python3 -m pytest -v mobject/test.py
+      - run: python3 --version ; pip --version
+      - run: python3 -m pytest -v mobject/test.py
+      - run: sudo pip install flake8
+      # stop the build if there are Python syntax errors or undefined names
+      - run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+      # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      
+      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree