### PR TITLE
Import fix

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,16 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import sys
 import os
+import mock
+
+MOCK_MODULES = [
+    'numpy',
+    'scipy',
+    'scipy.integrate',
+    'scipy.special',
+]
+for mod_name in MOCK_MODULES:
+    sys.modules[mod_name] = mock.Mock()
 sys.path.insert(0, os.path.abspath(".."))
 
 


### PR DESCRIPTION
Attempting to enable autodocs using the solution from https://stackoverflow.com/questions/36678131/readthedocs-not-parsing-docstrings-in-python-modules-sphinx