### PR TITLE
Updated link and text

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -2,11 +2,11 @@ Getting Started
 ===============
 
 Todd Zimmerman put together `a very nice tutorial`_ on getting started with
-``manim``, but is unfortunately outdated. It's still useful for understanding
-how ``manim`` is used, but the examples won't run on the latest version of
+``manim``. It's useful for understanding
+how ``manim`` is used, with working examples that run on the latest version of
 ``manim``.
 
-.. _a very nice tutorial: https://talkingphysics.wordpress.com/2018/06/11/learning-how-to-animate-videos-using-``manim``-series-a-journey/
+.. _a very nice tutorial: https://talkingphysics.wordpress.com/2019/01/08/getting-started-animating-with-manim-and-python-3-7/
 
 .. toctree::
     :caption: Contents:


### PR DESCRIPTION
Changed the link to the Python 3.7 tutorial and changed the text to state the examples are working with the current version of manim.